### PR TITLE
Adds ability to import user-defined attributes

### DIFF
--- a/docs/resources/entry.md
+++ b/docs/resources/entry.md
@@ -127,12 +127,10 @@ The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/c
 
 ```shell
 #!/bin/bash
-# Import an existing LDAP entry using its DN
-terraform import ldap_entry.user "cn=john.doe,ou=users,dc=example,dc=com"
+# Simple DN (default - imports only objectClass):
+terraform import ldap_entry.user "CN=user,OU=Users,DC=example,DC=com"
 
-# Import a group entry
-terraform import ldap_entry.group "cn=developers,ou=groups,dc=example,dc=com"
-
-# Import an organizational unit
-terraform import ldap_entry.department "ou=engineering,dc=example,dc=com"
+# JSON with specific attributes:
+terraform import ldap_entry.user '{"dn": "CN=user,OU=Users,DC=example,DC=com", "attributes": ["objectClass", "cn", "sAMAccountName",
+  "userPrincipalName"]}'
 ```

--- a/examples/resources/ldap_entry/import.sh
+++ b/examples/resources/ldap_entry/import.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
-# Import an existing LDAP entry using its DN
-terraform import ldap_entry.user "cn=john.doe,ou=users,dc=example,dc=com"
+# Simple DN (default - imports only objectClass):
+terraform import ldap_entry.user "CN=user,OU=Users,DC=example,DC=com"
 
-# Import a group entry
-terraform import ldap_entry.group "cn=developers,ou=groups,dc=example,dc=com"
-
-# Import an organizational unit
-terraform import ldap_entry.department "ou=engineering,dc=example,dc=com"
+# JSON with specific attributes:
+terraform import ldap_entry.user '{"dn": "CN=user,OU=Users,DC=example,DC=com", "attributes": ["objectClass", "cn", "sAMAccountName",
+  "userPrincipalName"]}'


### PR DESCRIPTION
This fixes workflow issues with importing existing entries by allowing users to specify which entries to import. Also provides a simple import that only causes `objectClass` to be imported into the state, allowing the user to further specify which attributes to manage later in their config.