### PR TITLE
Feature/empty attributes

### DIFF
--- a/internal/provider/ldap_entry_resource.go
+++ b/internal/provider/ldap_entry_resource.go
@@ -153,7 +153,10 @@ func (r *LdapEntryResource) Create(ctx context.Context, req resource.CreateReque
 	// Create LDAP add request
 	addReq := ldap.NewAddRequest(plan.DN.ValueString(), nil)
 	for attr, values := range attributes {
-		addReq.Attribute(attr, values)
+		// Skip attributes with empty values - LDAP servers reject empty attributes during creation
+		if len(values) > 0 {
+			addReq.Attribute(attr, values)
+		}
 	}
 
 	// Execute LDAP add operation

--- a/internal/provider/ldap_entry_resource_test.go
+++ b/internal/provider/ldap_entry_resource_test.go
@@ -279,7 +279,7 @@ resource "ldap_entry" "test_user" {
     cn = ["Test User"]
     sn = ["User"]
     uid = ["testuser"]
-		mail = [%s]
+    mail = [%s]
   }
 }
 `, mails)

--- a/internal/provider/ldap_entry_resource_test.go
+++ b/internal/provider/ldap_entry_resource_test.go
@@ -58,6 +58,11 @@ func TestAccLdapEntryResource(t *testing.T) {
 						tfjsonpath.New("id"),
 						knownvalue.StringExact("cn=test,dc=example,dc=com"),
 					),
+					statecheck.ExpectKnownValue(
+						"ldap_entry.test",
+						tfjsonpath.New("attributes"),
+						knownvalue.MapSizeExact(5),
+					),
 				},
 			},
 			// Update and Read testing - remove attributes
@@ -68,6 +73,12 @@ func TestAccLdapEntryResource(t *testing.T) {
 						"ldap_entry.test",
 						tfjsonpath.New("dn"),
 						knownvalue.StringExact("cn=test,dc=example,dc=com"),
+					),
+					// Ensure description is no longer present in the state
+					statecheck.ExpectKnownValue(
+						"ldap_entry.test",
+						tfjsonpath.New("attributes"),
+						knownvalue.MapSizeExact(4),
 					),
 				},
 			},

--- a/internal/provider/ldap_entry_resource_test.go
+++ b/internal/provider/ldap_entry_resource_test.go
@@ -155,6 +155,31 @@ func TestAccLdapEntryResource_EmptyAttributes(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckLdapEntryDestroy,
 		Steps: []resource.TestStep{
+			// Step 1: Create a user with empty mail
+			{
+				Config: testAccLdapEntryResourceConfigEmptyAttribute(``),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ldap_entry.test_user",
+						tfjsonpath.New("dn"),
+						knownvalue.StringExact("uid=testuser,dc=example,dc=com"),
+					),
+					statecheck.ExpectKnownValue(
+						"ldap_entry.test_user",
+						tfjsonpath.New("attributes").AtMapKey("mail"),
+						knownvalue.ListSizeExact(0),
+					),
+				},
+			},
+		},
+	})
+}
+func TestAccLdapEntryResource_EmptyAttributesTransition(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckLdapEntryDestroy,
+		Steps: []resource.TestStep{
 			// Step 1: Create a user with two mails
 			{
 				Config: testAccLdapEntryResourceConfigEmptyAttribute(`"foo@example.com", "bar@example.com"`),


### PR DESCRIPTION
* Empty attributes are now sent as Delete operations
* Empty attributes will be consistent in state, even if LDAP server doesn't return the attribute
* More robust tests around empty attributes